### PR TITLE
Fix warning C28218 in Tracelogging.h

### DIFF
--- a/include/wil/Tracelogging.h
+++ b/include/wil/Tracelogging.h
@@ -1510,7 +1510,7 @@ public: \
 
 #define __IMPLEMENT_CALLCONTEXT_CLASS(ActivityClassName) \
 protected: \
-    ActivityClassName(_In_opt_ void**, PCSTR contextName, _In_opt_ _Printf_format_string_ PCSTR formatString, _In_opt_ va_list argList) : \
+    ActivityClassName(_In_opt_ void**, PCSTR contextName, _In_ _Printf_format_string_ PCSTR formatString, _In_opt_ va_list argList) : \
         ActivityBase(contextName) \
     { \
         GetCallContext()->SetMessage(formatString, argList); \


### PR DESCRIPTION
`__IMPLEMENT_CALLCONTEXT_CLASS` defines its `ActivityClassName` constructor as taking a `formatString` parameter annotated as `_In_opt_ _Printf_format_string_`, then passes this `formatString` to `SetMessage()`.

https://github.com/oldnewthing/wil/blob/5f63f8d577e0718cc57261f821faa5ea7da5cbb9/include/wil/Tracelogging.h#L1511-L1516

but then for

Unfortunately, SetMessage is annotated as `_Printf_format_string_` (null not allowed), which is a C28218 warning.

https://github.com/oldnewthing/wil/blob/5f63f8d577e0718cc57261f821faa5ea7da5cbb9/include/wil/Tracelogging.h#L311

Turns out we never pass null as the `formatString` to the `ActivityClassName` constructor, the `_In_opt_` annotation was unnecessarily generous. Change it from `_In_opt_` to `_In_` to avoid the warning.